### PR TITLE
Adding Leaderboard V3, Fixing Card in AccountDetails

### DIFF
--- a/valo_api/endpoints_config.py
+++ b/valo_api/endpoints_config.py
@@ -9,7 +9,7 @@ from valo_api.endpoint import Endpoint
 from valo_api.responses.account_details import AccountDetailsV1
 from valo_api.responses.competitive_updates_raw import CompetitiveUpdatesRawV1
 from valo_api.responses.content import ContentV1
-from valo_api.responses.leaderboard import LeaderboardPlayerV1, LeaderboardV2
+from valo_api.responses.leaderboard import LeaderboardV3
 from valo_api.responses.lifetime_match import LifetimeMatchV1
 from valo_api.responses.match_details_raw import MatchDetailsRawV1
 from valo_api.responses.match_history import MatchHistoryPointV3
@@ -158,29 +158,35 @@ class EndpointsConfig(Enum):
         kwargs=OrderedDict([("version", str), ("countrycode", str)]),
     )
     LEADERBOARD = Endpoint(
-        path="/valorant/{version}/leaderboard/{region}",
+        path="/valorant/{version}/leaderboard/{region}/{platform}",
         f_name="get_leaderboard",
-        versions=["v1", "v2"],
-        return_type=Union[LeaderboardV2, List[LeaderboardPlayerV1]],
+        versions=["v3"],
+        return_type=LeaderboardV3,
         data_response=False,
         kwargs=OrderedDict(
             [
                 ("version", str),
                 ("region", str),
+                ("platform", str),
                 ("puuid", Optional[str]),
                 ("name", Optional[str]),
                 ("tag", Optional[str]),
+                ("season_short", Optional[str]),
                 ("season_id", Optional[str]),
-                ("start", Optional[int]),
+                ("size", Optional[int]),
+                ("start_index", Optional[int]),
             ]
         ),
         query_args=OrderedDict(
             [
+                
                 ("puuid", "{puuid}"),
                 ("name", "{name}"),
                 ("tag", "{tag}"),
+                ("season_short", "{season_short}"),
                 ("season_id", "{season_id}"),
-                ("start", "{start}"),
+                ("size", "{size}"),
+                ("start_index", "{start_index}"),
             ]
         ),
     )

--- a/valo_api/endpoints_config.py
+++ b/valo_api/endpoints_config.py
@@ -179,7 +179,6 @@ class EndpointsConfig(Enum):
         ),
         query_args=OrderedDict(
             [
-                
                 ("puuid", "{puuid}"),
                 ("name", "{name}"),
                 ("tag", "{tag}"),

--- a/valo_api/responses/account_details.py
+++ b/valo_api/responses/account_details.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from valo_api.utils.dict_struct import DictStruct
 
+
 class AccountDetailsV1(DictStruct):
     puuid: str
     region: str

--- a/valo_api/responses/account_details.py
+++ b/valo_api/responses/account_details.py
@@ -2,20 +2,12 @@ from typing import Optional
 
 from valo_api.utils.dict_struct import DictStruct
 
-
-class AccountCardV1(DictStruct):
-    id: str
-    small: str
-    large: str
-    wide: str
-
-
 class AccountDetailsV1(DictStruct):
     puuid: str
     region: str
     account_level: int
     name: str
     tag: str
-    card: Optional[AccountCardV1] = None
+    card: str
     last_update: Optional[str] = None
     last_update_raw: Optional[int] = None

--- a/valo_api/responses/leaderboard.py
+++ b/valo_api/responses/leaderboard.py
@@ -2,34 +2,18 @@ from typing import List, Optional
 
 from valo_api.utils.dict_struct import DictStruct
 
-
-class LeaderboardPlayerV1(DictStruct):
-    PlayerCardID: str
-    TitleID: str
-    IsBanned: bool
-    IsAnonymized: bool
-    puuid: str
-    gameName: str
-    tagLine: str
-    leaderboardRank: int
-    rankedRating: int
-    numberOfWins: int
-    competitiveTier: int
-
-
 class LeaderboardPlayerV2(DictStruct):
     PlayerCardID: str
     TitleID: str
     IsBanned: bool
     IsAnonymized: bool
-    puuid: str
+    puuid: Optional[str]
     gameName: str
     tagLine: str
     leaderboardRank: int
     rankedRating: int
     numberOfWins: int
     competitiveTier: int
-
 
 class LeaderboardV2(DictStruct):
     total_players: int
@@ -40,3 +24,42 @@ class LeaderboardV2(DictStruct):
     players: List[Optional[LeaderboardPlayerV2]]
     last_update: Optional[int] = None
     next_update: Optional[int] = None
+
+class LeaderboardThresholdTierV3(DictStruct):
+    id: int
+    name: str
+
+class LeaderboardThresholdV3(DictStruct):
+    tier: LeaderboardThresholdTierV3
+    start_index: int
+    threshold: int
+
+class LeaderboardResultsV3(DictStruct):
+    total: int
+    returned: int
+    before: int
+    after: int
+
+class LeaderboardPlayerV3(DictStruct):
+    card: str
+    title: str
+    is_banned: bool
+    is_anonymized: bool
+    puuid: Optional[str]
+    name: str
+    tag: str
+    leaderboard_rank: int
+    tier: int
+    rr: int
+    wins: int
+    updated_at: str
+
+class LeaderboardDataV3(DictStruct):
+    updated_at: str
+    thresholds: List[LeaderboardThresholdV3]
+    players: List[Optional[LeaderboardPlayerV3]]
+
+class LeaderboardV3(DictStruct):
+    status: int
+    results: LeaderboardResultsV3
+    data: LeaderboardDataV3


### PR DESCRIPTION
## Description

I added leaderboard v3 with its classes and own parameters, and removed the not supported v1 of the leaderboard, v2 is still in the code, but not accessible, because I don't know how to do that because of the platform which is needed in the path for v3 XD

Account Details also had a small issue, since the new API update the card is now a string with its ID, instead of an own class with all the links of the images

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/raimannma/ValorantAPI/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/raimannma/ValorantAPI/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
